### PR TITLE
PB-1216 improvements to customer and order data transformation

### DIFF
--- a/cartridges/int_pennyblack/cartridge/scripts/pennyblack/OrderToPayloadTransformer.js
+++ b/cartridges/int_pennyblack/cartridge/scripts/pennyblack/OrderToPayloadTransformer.js
@@ -31,7 +31,7 @@ OrderToPayloadTransformer.prototype._buildCustomerData = function () {
   if (this._order.defaultShipment.shippingAddress) {
     customer.first_name = this._order.defaultShipment.shippingAddress.firstName;
     customer.last_name = this._order.defaultShipment.shippingAddress.lastName;
-  } else if (this._order.billingAddress) {
+  } else {
     customer.first_name = this._order.billingAddress.firstName;
     customer.last_name = this._order.billingAddress.lastName;
   }

--- a/test/data/order/guestWithNoShippingAddress.json
+++ b/test/data/order/guestWithNoShippingAddress.json
@@ -1,0 +1,50 @@
+{
+  "orderNo": "3",
+  "externalOrderNo": "#3",
+  "billingAddress": {
+    "firstName": "John",
+    "lastName": "Doe",
+    "countryCode": {
+      "value": "gb"
+    },
+    "city": "London",
+    "postalCode": "ME1 2DR"
+  },
+  "couponLineItems": [
+    {
+      "couponCode": "TEST_COUPON_CODE_01"
+    }
+  ],
+  "creationDate": "2023-07-17T14:15:36.046Z",
+  "currencyCode": "GBP",
+  "customerLocaleID": "en_GB",
+  "customer": {
+    "ID": 10,
+    "anonymous": true,
+    "orderHistory": {
+      "orderCount": 0
+    }
+  },
+  "customerEmail": "john.doe@example.com",
+  "defaultShipment": {
+    "shippingAddress": null
+  },
+  "shipments": [
+    {
+      "giftMessage": "Test gift message 1"
+    },
+    {
+      "giftMessage": "Test gift message 2"
+    }
+  ],
+  "totalGrossPrice": {
+    "value": 10.05
+  },
+  "productLineItems": [
+    {
+      "productID": "001",
+      "manufacturerSKU": "TEST-001",
+      "productName": "Test Product 01"
+    }
+  ]
+}

--- a/test/unit/OrderToPayloadTransformer.spec.js
+++ b/test/unit/OrderToPayloadTransformer.spec.js
@@ -5,6 +5,7 @@ const DataLoader = require('../data/DataLoader');
 const Locale = require('../mocks/dw/util/Locale');
 const Order = require('../mocks/dw/order/Order');
 const OrderMgr = require('../mocks/dw/order/OrderMgr');
+const Collection = require('../mocks/dw/util/Collection');
 
 describe('OrderToPayloadTransformer', function () {
   describe('transform()', function () {
@@ -96,7 +97,7 @@ describe('OrderToPayloadTransformer', function () {
 
       it('sets order.billing_country to the country as set in the billing address of the order', function () {
         let payload = new OrderToPayloadTransformer().transform(new Order(DataLoader('order', 'guestWithNoHistory')));
-        expect(payload.order.billing_country).to.eq('gb');
+        expect(payload.order.billing_country).to.eq('GB');
       });
 
       it('sets order.billing_postcode to the postcode as set in the billing address of the order', function () {
@@ -111,7 +112,7 @@ describe('OrderToPayloadTransformer', function () {
 
       it('sets order.shipping_country to the country as set in the shipping address of the order', function () {
         let payload = new OrderToPayloadTransformer().transform(new Order(DataLoader('order', 'guestWithNoHistory')));
-        expect(payload.order.shipping_country).to.eq('gb');
+        expect(payload.order.shipping_country).to.eq('GB');
       });
 
       it('sets order.shipping_postcode to the postcode as set in the shipping address of the order', function () {
@@ -173,6 +174,77 @@ describe('OrderToPayloadTransformer', function () {
         data.customerLocaleID = 'de_DE';
         let payload = new OrderToPayloadTransformer().transform(new Order(data));
         expect('language' in payload.customer).to.eq(false);
+      });
+
+      it('falls back to billing address when no shipping address is present', function () {
+        let payload = new OrderToPayloadTransformer().transform(
+          new Order(DataLoader('order', 'guestWithNoShippingAddress')),
+        );
+        expect(payload.customer.first_name).to.eq('John');
+        expect(payload.customer.last_name).to.eq('Doe');
+      });
+
+      it('skips shipping_country when not specified', function () {
+        let data = DataLoader('order', 'guestWithNoHistory');
+        data.defaultShipment.shippingAddress.countryCode = null;
+        let payload = new OrderToPayloadTransformer().transform(new Order(data));
+        expect('shipping_country' in payload.order).to.eq(false);
+      });
+
+      it('skips shipping_postcode when not specified', function () {
+        let data = DataLoader('order', 'guestWithNoHistory');
+        data.defaultShipment.shippingAddress.postalCode = null;
+        let payload = new OrderToPayloadTransformer().transform(new Order(data));
+        expect('shipping_postcode' in payload.order).to.eq(false);
+      });
+
+      it('skips shipping_city when not specified', function () {
+        let data = DataLoader('order', 'guestWithNoHistory');
+        data.defaultShipment.shippingAddress.city = null;
+        let payload = new OrderToPayloadTransformer().transform(new Order(data));
+        expect('shipping_city' in payload.order).to.eq(false);
+      });
+
+      it('skips billing_country when not specified', function () {
+        let data = DataLoader('order', 'guestWithNoHistory');
+        data.billingAddress.countryCode = null;
+        let payload = new OrderToPayloadTransformer().transform(new Order(data));
+        expect('billing_country' in payload.order).to.eq(false);
+      });
+
+      it('skips billing_postcode when not specified', function () {
+        let data = DataLoader('order', 'guestWithNoHistory');
+        data.billingAddress.postalCode = null;
+        let payload = new OrderToPayloadTransformer().transform(new Order(data));
+        expect('billing_postcode' in payload.order).to.eq(false);
+      });
+
+      it('skips billing_city when not specified', function () {
+        let data = DataLoader('order', 'guestWithNoHistory');
+        data.billingAddress.city = null;
+        let payload = new OrderToPayloadTransformer().transform(new Order(data));
+        expect('billing_city' in payload.order).to.eq(false);
+      });
+
+      it('skips skus when not specified', function () {
+        let data = DataLoader('order', 'guestWithNoHistory');
+        data.productLineItems = new Collection([]);
+        let payload = new OrderToPayloadTransformer().transform(new Order(data));
+        expect('skus' in payload.order).to.eq(false);
+      });
+
+      it('skips product_titles when not specified', function () {
+        let data = DataLoader('order', 'guestWithNoHistory');
+        data.productLineItems = new Collection([]);
+        let payload = new OrderToPayloadTransformer().transform(new Order(data));
+        expect('product_titles' in payload.order).to.eq(false);
+      });
+
+      it('skips promo_codes when not specified', function () {
+        let data = DataLoader('order', 'guestWithNoHistory');
+        data.couponLineItems = new Collection([]);
+        let payload = new OrderToPayloadTransformer().transform(new Order(data));
+        expect('promo_codes' in payload.order).to.eq(false);
       });
     });
 


### PR DESCRIPTION
**Language**
Not all Locale's have a language code set so lets make this optional

**Shipping Address**
When a shipping address is not set fallback to the OrderAddress (aka BillingAddress) for the first and last name

**Address Details**
Allow individual components of an address to be skipped when not set.

**Country Codes**
The casing of country codes can vary, to improve consistency they are now always upper cased.